### PR TITLE
Migrate to TypeScript and add type definitions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,17 @@
 module.exports = {
-  extends: 'google',
-  env: {
-    node: true,
-    mocha: true
-  },
+  root: true,
+  parser: '@typescript-eslint/parser',
   plugins: [
-    'pabigot'
+    '@typescript-eslint',
+  ],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
   ],
   rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
     'guard-for-in': 'off',
     'prefer-rest-params': 'off',
     'prefer-spread': 'off',
@@ -23,12 +27,6 @@ module.exports = {
     'no-irregular-whitespace': ['error', {skipComments: true}],
     'no-multi-spaces': ['error', {ignoreEOLComments: true}],
     'operator-linebreak': ['error', 'before'],
-    'pabigot/affixed-ids': ['error', {
-      allowedSuffixes: [
-        '_dCel',
-        '_ppt'
-      ]
-    }],
     quotes: ['error', 'single', {
       avoidEscape: true,
       allowTemplateLiterals: true
@@ -40,6 +38,6 @@ module.exports = {
     yoda: ['error', 'always', {exceptRange: true}]
   },
   parserOptions: {
-    sourceType: 'module'
+    project: './tsconfig.json',
   }
-}
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /CHANGELOG.html
 /coverage/
 /node_modules/
+/lib/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - "node"
   - "8"
   - "6"
-  - "4"
 after_success:
   - npm run eslint
   - npm run coveralls

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [3.0.0] - 2021-07-08
+
+* **API** Renamed `const` function to [constant][doc:constant].
+* Migrate to TypeScript and make type definitions available from npm.
+
 ## [2.0.0] - 2021-07-08
 
 * Improve [browser compatibility][pr#28] by adding a browser polyfill

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Change Log
 
+## [2.0.0] - 2021-07-08
+
+* Improve [browser compatibility][pr#28] by adding a browser polyfill
+  for the Node browser module and loosening types from Buffer to Uint8Array.
+
 ## [1.2.2] - 2021-07-05
 
-* Improve [browser compatibility][pr#26] by eliminating a dependence on
+* Improve [browser compatibility][pr#27] by eliminating a dependence on
   the Node assert module.
 
 ## [1.2.1] - 2021-04-29

--- a/lib/Layout.js
+++ b/lib/Layout.js
@@ -22,7 +22,7 @@
  */
 
 /**
- * Support for translating between Buffer instances and JavaScript
+ * Support for translating between Uint8Array instances and JavaScript
  * native types.
  *
  * {@link module:Layout~Layout|Layout} is the basis of a class
@@ -132,6 +132,27 @@
 
 'use strict';
 
+const Buffer = require('buffer').Buffer;
+
+/* Check if a value is a Uint8Array.
+ *
+ * @ignore */
+function checkUint8Array(b) {
+  if (!(b instanceof Uint8Array)) {
+    throw new TypeError('b must be a Uint8Array');
+  }
+}
+exports.checkUint8Array = checkUint8Array;
+
+/* Create a Buffer instance from a Uint8Array.
+ *
+ * @ignore */
+function uint8ArrayToBuffer(b) {
+  checkUint8Array(b);
+  return Buffer.from(b.buffer, b.byteOffset, b.length);
+}
+exports.uint8ArrayToBuffer = uint8ArrayToBuffer;
+
 /**
  * Base class for layout objects.
  *
@@ -196,9 +217,9 @@ class Layout {
   }
 
   /**
-   * Decode from a Buffer into an JavaScript value.
+   * Decode from a Uint8Array into a JavaScript value.
    *
-   * @param {Buffer} b - the buffer from which encoded data is read.
+   * @param {Uint8Array} b - the buffer from which encoded data is read.
    *
    * @param {Number} [offset] - the offset at which the encoded data
    * starts.  If absent a zero offset is inferred.
@@ -212,13 +233,13 @@ class Layout {
   }
 
   /**
-   * Encode a JavaScript value into a Buffer.
+   * Encode a JavaScript value into a Uint8Array.
    *
    * @param {(Number|Array|Object)} src - the value to be encoded into
    * the buffer.  The type accepted depends on the (sub-)type of {@link
    * Layout}.
    *
-   * @param {Buffer} b - the buffer into which encoded data will be
+   * @param {Uint8Array} b - the buffer into which encoded data will be
    * written.
    *
    * @param {Number} [offset] - the offset at which the encoded data
@@ -240,7 +261,7 @@ class Layout {
   /**
    * Calculate the span of a specific instance of a layout.
    *
-   * @param {Buffer} b - the buffer that contains an encoded instance.
+   * @param {Uint8Array} b - the buffer that contains an encoded instance.
    *
    * @param {Number} [offset] - the offset at which the encoded instance
    * starts.  If absent a zero offset is inferred.
@@ -456,6 +477,7 @@ class GreedyCount extends ExternalLayout {
 
   /** @override */
   decode(b, offset) {
+    checkUint8Array(b);
     if (undefined === offset) {
       offset = 0;
     }
@@ -510,7 +532,7 @@ class OffsetLayout extends ExternalLayout {
      * start of another layout.
      *
      * The value may be positive or negative, but an error will thrown
-     * if at the point of use it goes outside the span of the Buffer
+     * if at the point of use it goes outside the span of the Uint8Array
      * being accessed.  */
     this.offset = offset;
   }
@@ -567,7 +589,7 @@ class UInt extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readUIntLE(offset, this.span);
+    return uint8ArrayToBuffer(b).readUIntLE(offset, this.span);
   }
 
   /** @override */
@@ -575,7 +597,7 @@ class UInt extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeUIntLE(src, offset, this.span);
+    uint8ArrayToBuffer(b).writeUIntLE(src, offset, this.span);
     return this.span;
   }
 }
@@ -609,7 +631,7 @@ class UIntBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readUIntBE(offset, this.span);
+    return uint8ArrayToBuffer(b).readUIntBE(offset, this.span);
   }
 
   /** @override */
@@ -617,7 +639,7 @@ class UIntBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeUIntBE(src, offset, this.span);
+    uint8ArrayToBuffer(b).writeUIntBE(src, offset, this.span);
     return this.span;
   }
 }
@@ -651,7 +673,7 @@ class Int extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readIntLE(offset, this.span);
+    return uint8ArrayToBuffer(b).readIntLE(offset, this.span);
   }
 
   /** @override */
@@ -659,7 +681,7 @@ class Int extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeIntLE(src, offset, this.span);
+    uint8ArrayToBuffer(b).writeIntLE(src, offset, this.span);
     return this.span;
   }
 }
@@ -693,7 +715,7 @@ class IntBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readIntBE(offset, this.span);
+    return uint8ArrayToBuffer(b).readIntBE(offset, this.span);
   }
 
   /** @override */
@@ -701,7 +723,7 @@ class IntBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeIntBE(src, offset, this.span);
+    uint8ArrayToBuffer(b).writeIntBE(src, offset, this.span);
     return this.span;
   }
 }
@@ -741,6 +763,7 @@ class NearUInt64 extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
+    b = uint8ArrayToBuffer(b);
     const lo32 = b.readUInt32LE(offset);
     const hi32 = b.readUInt32LE(offset + 4);
     return roundedInt64(hi32, lo32);
@@ -752,6 +775,7 @@ class NearUInt64 extends Layout {
       offset = 0;
     }
     const split = divmodInt64(src);
+    b = uint8ArrayToBuffer(b);
     b.writeUInt32LE(split.lo32, offset);
     b.writeUInt32LE(split.hi32, offset + 4);
     return 8;
@@ -779,6 +803,7 @@ class NearUInt64BE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
+    b = uint8ArrayToBuffer(b);
     const hi32 = b.readUInt32BE(offset);
     const lo32 = b.readUInt32BE(offset + 4);
     return roundedInt64(hi32, lo32);
@@ -790,6 +815,7 @@ class NearUInt64BE extends Layout {
       offset = 0;
     }
     const split = divmodInt64(src);
+    b = uint8ArrayToBuffer(b);
     b.writeUInt32BE(split.hi32, offset);
     b.writeUInt32BE(split.lo32, offset + 4);
     return 8;
@@ -817,6 +843,7 @@ class NearInt64 extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
+    b = uint8ArrayToBuffer(b);
     const lo32 = b.readUInt32LE(offset);
     const hi32 = b.readInt32LE(offset + 4);
     return roundedInt64(hi32, lo32);
@@ -828,6 +855,7 @@ class NearInt64 extends Layout {
       offset = 0;
     }
     const split = divmodInt64(src);
+    b = uint8ArrayToBuffer(b);
     b.writeUInt32LE(split.lo32, offset);
     b.writeInt32LE(split.hi32, offset + 4);
     return 8;
@@ -855,6 +883,7 @@ class NearInt64BE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
+    b = uint8ArrayToBuffer(b);
     const hi32 = b.readInt32BE(offset);
     const lo32 = b.readUInt32BE(offset + 4);
     return roundedInt64(hi32, lo32);
@@ -866,6 +895,7 @@ class NearInt64BE extends Layout {
       offset = 0;
     }
     const split = divmodInt64(src);
+    b = uint8ArrayToBuffer(b);
     b.writeInt32BE(split.hi32, offset);
     b.writeUInt32BE(split.lo32, offset + 4);
     return 8;
@@ -892,7 +922,7 @@ class Float extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readFloatLE(offset);
+    return uint8ArrayToBuffer(b).readFloatLE(offset);
   }
 
   /** @override */
@@ -900,7 +930,7 @@ class Float extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeFloatLE(src, offset);
+    uint8ArrayToBuffer(b).writeFloatLE(src, offset);
     return 4;
   }
 }
@@ -925,7 +955,7 @@ class FloatBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readFloatBE(offset);
+    return uint8ArrayToBuffer(b).readFloatBE(offset);
   }
 
   /** @override */
@@ -933,7 +963,7 @@ class FloatBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeFloatBE(src, offset);
+    uint8ArrayToBuffer(b).writeFloatBE(src, offset);
     return 4;
   }
 }
@@ -958,7 +988,7 @@ class Double extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readDoubleLE(offset);
+    return uint8ArrayToBuffer(b).readDoubleLE(offset);
   }
 
   /** @override */
@@ -966,7 +996,7 @@ class Double extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeDoubleLE(src, offset);
+    uint8ArrayToBuffer(b).writeDoubleLE(src, offset);
     return 8;
   }
 }
@@ -991,7 +1021,7 @@ class DoubleBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    return b.readDoubleBE(offset);
+    return uint8ArrayToBuffer(b).readDoubleBE(offset);
   }
 
   /** @override */
@@ -999,7 +1029,7 @@ class DoubleBE extends Layout {
     if (undefined === offset) {
       offset = 0;
     }
-    b.writeDoubleBE(src, offset);
+    uint8ArrayToBuffer(b).writeDoubleBE(src, offset);
     return 8;
   }
 }
@@ -1225,6 +1255,7 @@ class Structure extends Layout {
 
   /** @override */
   decode(b, offset) {
+    checkUint8Array(b);
     if (undefined === offset) {
       offset = 0;
     }
@@ -1746,17 +1777,17 @@ class Union extends Layout {
    * If `vb` does not produce a registered variant the function returns
    * `undefined`.
    *
-   * @param {(Number|Buffer)} vb - either the variant number, or a
+   * @param {(Number|Uint8Array)} vb - either the variant number, or a
    * buffer from which the discriminator is to be read.
    *
    * @param {Number} offset - offset into `vb` for the start of the
-   * union.  Used only when `vb` is an instance of {Buffer}.
+   * union.  Used only when `vb` is an instance of {Uint8Array}.
    *
    * @return {({VariantLayout}|undefined)}
    */
   getVariant(vb, offset) {
     let variant = vb;
-    if (Buffer.isBuffer(vb)) {
+    if (vb instanceof Uint8Array) {
       if (undefined === offset) {
         offset = 0;
       }
@@ -2251,7 +2282,7 @@ class Boolean extends BitField {
 
 /**
  * Contain a fixed-length block of arbitrary data, represented as a
- * Buffer.
+ * Uint8Array.
  *
  * *Factory*: {@link module:Layout.blob|blob}
  *
@@ -2303,7 +2334,7 @@ class Blob extends Layout {
     if (0 > span) {
       span = this.length.decode(b, offset);
     }
-    return b.slice(offset, offset + span);
+    return uint8ArrayToBuffer(b).slice(offset, offset + span);
   }
 
   /** Implement {@link Layout#encode|encode} for {@link Blob}.
@@ -2316,15 +2347,14 @@ class Blob extends Layout {
     if (this.length instanceof ExternalLayout) {
       span = src.length;
     }
-    if (!(Buffer.isBuffer(src)
-          && (span === src.length))) {
+    if (!(src instanceof Uint8Array && span === src.length)) {
       throw new TypeError(nameWithProperty('Blob.encode', this)
-                          + ' requires (length ' + span + ') Buffer as src');
+                          + ' requires (length ' + span + ') Uint8Array as src');
     }
     if ((offset + span) > b.length) {
-      throw new RangeError('encoding overruns Buffer');
+      throw new RangeError('encoding overruns Uint8Array');
     }
-    b.write(src.toString('hex'), offset, span, 'hex');
+    uint8ArrayToBuffer(b).write(src.toString('hex'), offset, span, 'hex');
     if (this.length instanceof ExternalLayout) {
       this.length.encode(span, b, offset);
     }
@@ -2352,9 +2382,7 @@ class CString extends Layout {
 
   /** @override */
   getSpan(b, offset) {
-    if (!Buffer.isBuffer(b)) {
-      throw new TypeError('b must be a Buffer');
-    }
+    checkUint8Array(b);
     if (undefined === offset) {
       offset = 0;
     }
@@ -2371,11 +2399,12 @@ class CString extends Layout {
       offset = 0;
     }
     let span = this.getSpan(b, offset);
-    return b.slice(offset, offset + span - 1).toString('utf-8');
+    return uint8ArrayToBuffer(b).slice(offset, offset + span - 1).toString('utf-8');
   }
 
   /** @override */
   encode(src, b, offset) {
+    b = uint8ArrayToBuffer(b);
     if (undefined === offset) {
       offset = 0;
     }
@@ -2385,7 +2414,7 @@ class CString extends Layout {
     if ('string' !== typeof src) {
       src = src.toString();
     }
-    const srcb = new Buffer(src, 'utf8');
+    const srcb = Buffer.from(src, 'utf8');
     const span = srcb.length;
     if ((offset + span) > b.length) {
       throw new RangeError('encoding overruns Buffer');
@@ -2443,9 +2472,7 @@ class UTF8 extends Layout {
 
   /** @override */
   getSpan(b, offset) {
-    if (!Buffer.isBuffer(b)) {
-      throw new TypeError('b must be a Buffer');
-    }
+    checkUint8Array(b);
     if (undefined === offset) {
       offset = 0;
     }
@@ -2462,11 +2489,12 @@ class UTF8 extends Layout {
         && (this.maxSpan < span)) {
       throw new RangeError('text length exceeds maxSpan');
     }
-    return b.slice(offset, offset + span).toString('utf-8');
+    return uint8ArrayToBuffer(b).slice(offset, offset + span).toString('utf-8');
   }
 
   /** @override */
   encode(src, b, offset) {
+    b = uint8ArrayToBuffer(b);
     if (undefined === offset) {
       offset = 0;
     }
@@ -2476,7 +2504,7 @@ class UTF8 extends Layout {
     if ('string' !== typeof src) {
       src = src.toString();
     }
-    const srcb = new Buffer(src, 'utf8');
+    const srcb = Buffer.from(src, 'utf8');
     const span = srcb.length;
     if ((0 <= this.maxSpan)
         && (this.maxSpan < span)) {

--- a/lib/Layout.js
+++ b/lib/Layout.js
@@ -2354,9 +2354,11 @@ class Blob extends Layout {
     if ((offset + span) > b.length) {
       throw new RangeError('encoding overruns Uint8Array');
     }
-    uint8ArrayToBuffer(b).write(src.toString('hex'), offset, span, 'hex');
+    const buffer = uint8ArrayToBuffer(b);
+    const srcBuffer = uint8ArrayToBuffer(src);
+    buffer.write(srcBuffer.toString('hex'), offset, span, 'hex');
     if (this.length instanceof ExternalLayout) {
-      this.length.encode(span, b, offset);
+      this.length.encode(span, buffer, offset);
     }
     return span;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffer-layout",
-  "version": "1.2.2",
+  "version": "2.0.0",
   "description": "Translation between JavaScript values and Buffers",
   "keywords": [
     "Buffer",
@@ -17,6 +17,9 @@
   "license": "MIT",
   "author": "Peter A. Bigot <pab@pabigot.com>",
   "main": "./lib/Layout.js",
+  "dependencies": {
+    "buffer": "~6.0.3"
+  },
   "devDependencies": {
     "coveralls": "^3.0.0",
     "eslint": "~4.18.2",
@@ -28,7 +31,7 @@
     "mocha": "~5.0.4"
   },
   "engines": {
-    "node": ">=4.5"
+    "node": ">=5.10"
   },
   "scripts": {
     "coverage": "istanbul cover _mocha -- -u tdd",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buffer-layout",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Translation between JavaScript values and Buffers",
   "keywords": [
     "Buffer",
@@ -17,27 +17,34 @@
   "license": "MIT",
   "author": "Peter A. Bigot <pab@pabigot.com>",
   "main": "./lib/Layout.js",
+  "types": "./lib/Layout.d.ts",
+  "files": [
+    "/lib"
+  ],
   "dependencies": {
     "buffer": "~6.0.3"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.28.2",
+    "@typescript-eslint/parser": "^4.28.2",
     "coveralls": "^3.0.0",
-    "eslint": "~4.18.2",
-    "eslint-config-google": "~0.9.1",
-    "eslint-plugin-pabigot": "~1.1.0",
+    "eslint": "~7.30.0",
     "istanbul": "~0.4.5",
     "jsdoc": "~3.5.5",
     "lodash": "~4.17.5",
-    "mocha": "~5.0.4"
+    "mocha": "~5.0.4",
+    "typescript": "~4.3.5"
   },
   "engines": {
     "node": ">=5.10"
   },
   "scripts": {
-    "coverage": "istanbul cover _mocha -- -u tdd",
-    "coveralls": "istanbul cover _mocha --report lcovonly -- -u tdd && cat ./coverage/lcov.info | coveralls",
-    "eslint": "eslint lib/ test/",
+    "build": "tsc",
+    "coverage": "npm run build && istanbul cover _mocha -- -u tdd",
+    "coveralls": "npm run build && istanbul cover _mocha --report lcovonly -- -u tdd && cat ./coverage/lcov.info | coveralls",
+    "eslint": "eslint src/ --ext .ts",
     "jsdoc": "jsdoc -c jsdoc/conf.json",
-    "test": "mocha -u tdd"
+    "prepare": "npm run build",
+    "test": "npm run build && mocha -u tdd"
   }
 }

--- a/test/LayoutTest.js
+++ b/test/LayoutTest.js
@@ -1499,17 +1499,17 @@ suite('Layout', function() {
       assert.throws(() => new lo.BitField(bs, 40), Error);
     });
     suite('ctor argument processing', function() {
-      it('should infer property when passed string', function() {
+      test('should infer property when passed string', function() {
         const bs = new lo.BitStructure(lo.u8(), 'flags');
         assert.strictEqual(bs.msb, false);
         assert.strictEqual(bs.property, 'flags');
       });
-      it('should respect msb without property', function() {
+      test('should respect msb without property', function() {
         const bs = new lo.BitStructure(lo.u8(), true);
         assert.strictEqual(bs.msb, true);
         assert.strictEqual(bs.property, undefined);
       });
-      it('should accept msb with property', function() {
+      test('should accept msb with property', function() {
         const bs = new lo.BitStructure(lo.u8(), 'flags', 'flags');
         assert.strictEqual(bs.msb, true);
         assert.strictEqual(bs.property, 'flags');

--- a/test/LayoutTest.js
+++ b/test/LayoutTest.js
@@ -2004,14 +2004,14 @@ suite('Layout', function() {
     });
     test('basics', function() {
       const b = Buffer.from('', 'hex');
-      assert.strictEqual(lo.const(true).decode(b), true);
-      assert.strictEqual(lo.const(undefined).decode(b), undefined);
+      assert.strictEqual(lo.constant(true).decode(b), true);
+      assert.strictEqual(lo.constant(undefined).decode(b), undefined);
       const obj = {a: 23};
-      assert.strictEqual(lo.const(obj).decode(b), obj);
+      assert.strictEqual(lo.constant(obj).decode(b), obj);
       /* No return value to check, but this shouldn't throw an
        * exception (which it would if it tried to mutate the
        * zero-length buffer). */
-      assert.equal(lo.const(32).encode(b), 0);
+      assert.equal(lo.constant(32).encode(b), 0);
       assert.equal(b.length, 0);
     });
   });

--- a/test/examples.js
+++ b/test/examples.js
@@ -214,8 +214,8 @@ struct ds {
     const s16 = un.addVariant('h'.charCodeAt(0), lo.s16(), 's16');
     const s48 = un.addVariant('Q'.charCodeAt(0), lo.s48(), 's48');
     const cstr = un.addVariant('s'.charCodeAt(0), lo.cstr(), 'str');
-    const tr = un.addVariant('T'.charCodeAt(0), lo.const(true), 'b');
-    const fa = un.addVariant('F'.charCodeAt(0), lo.const(false), 'b');
+    const tr = un.addVariant('T'.charCodeAt(0), lo.constant(true), 'b');
+    const fa = un.addVariant('F'.charCodeAt(0), lo.constant(false), 'b');
     const b = Buffer.alloc(1 + 6);
     un.configGetSourceVariant(function(src) {
       if (src.hasOwnProperty('b')) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "module": "commonjs",
+    "declaration": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "outDir": "lib",
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.spec.ts"]
+}


### PR DESCRIPTION
Fixes https://github.com/pabigot/buffer-layout/issues/30

#### Changes
- Added type definitions to published npm package
- Added `prepare` npm script for building TypeScript source files
- Bumped version to 3.0.0 to release new type definitions
- Updated eslint config to lint typescript source files (excluded test files from linting temporarily)
- Renamed `BufferLayout.const` to `BufferLayout.constant`